### PR TITLE
Propage kminion pod custom labels as metrics labels

### DIFF
--- a/charts/kminion/templates/servicemonitor.yaml
+++ b/charts/kminion/templates/servicemonitor.yaml
@@ -27,4 +27,8 @@ spec:
   targetLabels:
     {{- toYaml .Values.serviceMonitor.targetLabels | nindent 4}}
   {{- end}}
+  {{- if .Values.customLabels }}
+  podTargetLabels:
+    {{- (keys .Values.customLabels | sortAlpha) | toYaml | nindent 4 }}
+  {{- end}}
  {{- end }}


### PR DESCRIPTION
When defined, the pod customLabels are propagates
to service monitor as podTargetLabels.
See https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#servicemonitorspec