### PR TITLE
Build multi-arch Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ############################################################
 # Build image
 ############################################################
-FROM golang:1.16-alpine as builder
+FROM --platform=$BUILDPLATFORM golang:1.17-alpine as builder
 RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates
 
 WORKDIR /app
@@ -12,12 +12,13 @@ RUN go mod download
 
 COPY . .
 
-RUN CGO_ENABLED=0 go build -o ./bin/kminion
+ARG TARGETOS TARGETARCH
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -o ./bin/kminion
 
 ############################################################
 # Runtime Image
 ############################################################
-FROM alpine:3
+FROM --platform=$TARGETPLATFORM alpine:3
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/bin/kminion /app/kminion
 


### PR DESCRIPTION
Based on https://medium.com/@tonistiigi/faster-multi-platform-builds-dockerfile-cross-compilation-guide-part-1-ec087c719eaf

A sample image built on Mac M1 with Docker Desktop is at https://hub.docker.com/r/solsson/kafka-consumers-prometheus. The build command can, I think, list any platforms supported by golang.

```
docker buildx build --platform=linux/amd64,linux/arm64/v8 -t solsson/kafka-consumers-prometheus --push .
```

I've tested the image on k3s running on Ubuntu ARM.