### PR TITLE
introduce library-friendly kafka config

### DIFF
--- a/kafka/config.go
+++ b/kafka/config.go
@@ -1,6 +1,9 @@
 package kafka
 
-import "fmt"
+import (
+	"fmt"
+	"io/ioutil"
+)
 
 type Config struct {
 	// General
@@ -35,4 +38,77 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+// InMemoryConfig is config that is suitable to be used when kminion is used as
+// library because it accept tls certs as byte arrays, not as file paths
+type InMemoryConfig struct {
+	// General
+	Brokers  []string
+	ClientID string
+	RackID   string
+
+	TLS  InMemoryTLSConfig
+	SASL SASLConfig
+}
+
+func (c *InMemoryConfig) SetDefaults() {
+	c.ClientID = "kminion"
+
+	c.TLS.SetDefaults()
+	c.SASL.SetDefaults()
+}
+
+func (c *InMemoryConfig) Validate() error {
+	if len(c.Brokers) == 0 {
+		return fmt.Errorf("no seed brokers specified, at least one must be configured")
+	}
+
+	err := c.TLS.Validate()
+	if err != nil {
+		return fmt.Errorf("failed to validate TLS config: %w", err)
+	}
+
+	err = c.SASL.Validate()
+	if err != nil {
+		return fmt.Errorf("failed to validate SASL config: %w", err)
+	}
+
+	return nil
+}
+
+func FromConfig(cfg Config) (InMemoryConfig, error) {
+	result := InMemoryConfig{
+		Brokers:  cfg.Brokers,
+		ClientID: cfg.ClientID,
+		RackID:   cfg.RackID,
+		SASL:     cfg.SASL,
+		TLS: InMemoryTLSConfig{
+			Enabled:               cfg.TLS.Enabled,
+			Passphrase:            cfg.TLS.Passphrase,
+			InsecureSkipTLSVerify: cfg.TLS.InsecureSkipTLSVerify,
+		},
+	}
+	if cfg.TLS.CaFilepath != "" {
+		ca, err := ioutil.ReadFile(cfg.TLS.CaFilepath)
+		if err != nil {
+			return result, err
+		}
+		result.TLS.Ca = ca
+	}
+	if cfg.TLS.CertFilepath != "" {
+		cert, err := ioutil.ReadFile(cfg.TLS.CertFilepath)
+		if err != nil {
+			return result, err
+		}
+		result.TLS.Cert = cert
+	}
+	if cfg.TLS.KeyFilepath != "" {
+		key, err := ioutil.ReadFile(cfg.TLS.KeyFilepath)
+		if err != nil {
+			return result, err
+		}
+		result.TLS.Key = key
+	}
+	return result, nil
 }

--- a/kafka/config_tls.go
+++ b/kafka/config_tls.go
@@ -17,3 +17,21 @@ func (c *TLSConfig) SetDefaults() {
 func (c *TLSConfig) Validate() error {
 	return nil
 }
+
+// InMemoryTLSConfig to connect to Kafka via TLS
+type InMemoryTLSConfig struct {
+	Enabled               bool
+	Ca                    []byte
+	Cert                  []byte
+	Key                   []byte
+	Passphrase            string
+	InsecureSkipTLSVerify bool
+}
+
+func (c *InMemoryTLSConfig) SetDefaults() {
+	c.Enabled = false
+}
+
+func (c *InMemoryTLSConfig) Validate() error {
+	return nil
+}

--- a/kafka/service.go
+++ b/kafka/service.go
@@ -14,15 +14,26 @@ import (
 )
 
 type Service struct {
-	cfg    Config
+	cfg    InMemoryConfig
 	logger *zap.Logger
 }
 
-func NewService(cfg Config, logger *zap.Logger) *Service {
+func NewService(cfg Config, logger *zap.Logger) (*Service, error) {
+	inMemoryCfg, err := FromConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &Service{
+		cfg:    inMemoryCfg,
+		logger: logger.Named("kafka_service"),
+	}, nil
+}
+
+func NewServiceFromConfig(cfg InMemoryConfig, logger *zap.Logger) (*Service, error) {
 	return &Service{
 		cfg:    cfg,
 		logger: logger.Named("kafka_service"),
-	}
+	}, nil
 }
 
 // CreateAndTestClient creates a client with the services default settings

--- a/main.go
+++ b/main.go
@@ -57,7 +57,10 @@ func main() {
 	wrappedRegisterer := promclient.WrapRegistererWithPrefix(cfg.Exporter.Namespace+"_", promclient.DefaultRegisterer)
 
 	// Create kafka service
-	kafkaSvc := kafka.NewService(cfg.Kafka, logger)
+	kafkaSvc, err := kafka.NewService(cfg.Kafka, logger)
+	if err != nil {
+		logger.Fatal("failed to setup kafka service", zap.Error(err))
+	}
 
 	// Create minion service
 	// Prometheus exporter only talks to the minion service which


### PR DESCRIPTION
Providing filepaths is not convenient when one wants to use kminion as a library and already have the certs in memory.