### PR TITLE
Optimize fetching of topic configs

### DIFF
--- a/minion/describe_topic_config.go
+++ b/minion/describe_topic_config.go
@@ -20,6 +20,7 @@ func (s *Service) GetTopicConfigs(ctx context.Context) (*kmsg.DescribeConfigsRes
 		resourceReq := kmsg.NewDescribeConfigsRequestResource()
 		resourceReq.ResourceType = kmsg.ConfigResourceTypeTopic
 		resourceReq.ResourceName = *topic.Topic
+                resourceReq.ConfigNames = s.Cfg.Topics.InfoMetric.ConfigKeys
 		req.Resources = append(req.Resources, resourceReq)
 	}
 


### PR DESCRIPTION
fix: #132 

It's unnecessary to fetch all config keys and only then filter them in memory.