### PR TITLE
Allow retry on failure during initial connection test

### DIFF
--- a/charts/kminion/values.yaml
+++ b/charts/kminion/values.yaml
@@ -171,6 +171,9 @@ kminion:
 #          username: ""
 #          password: ""
 #          realm: ""
+#      # Whether to retry the initial test connection to Kafka. False will exit with code 1 on error,
+#      # while true will retry until success.
+#      retryInitConnection: false
 #
 #    minion:
 #      consumerGroups:

--- a/kafka/config.go
+++ b/kafka/config.go
@@ -10,6 +10,8 @@ type Config struct {
 
 	TLS  TLSConfig  `koanf:"tls"`
 	SASL SASLConfig `koanf:"sasl"`
+
+	RetryInitConnection bool `koanf:"retryInitConnection"`
 }
 
 func (c *Config) SetDefaults() {


### PR DESCRIPTION
The PR adds an option that allows KMinion to retry the initial connection test on a failure instead of returning with exit code 1