### PR TITLE
build: Fix condition for semver docker tag

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -36,9 +36,10 @@ jobs:
           images: |
             vectorized/kminion
           # generate Docker tags based on the following events/attributes
+          # Semver type is only active on 'push tag' events, hence no enable condition required
           tags: |
             type=sha,prefix={{branch}}-,format=short,enable={{is_default_branch}}
-            type=semver,pattern={{raw}},enable=${{ github.event.action == 'published' }}
+            type=semver,pattern={{raw}}
 
       - name: Login to DockerHub
         uses: docker/login-action@v2


### PR DESCRIPTION
It seems like GitHub actions modified the `github.event` payload for push events. I could not find any changelog or documentation for this, but all documentation has been updated to switch to `github.event_name` nowadays. Because the docker-metadata-action already defaults to `push tag` events for tags with type `semver` we don't need the enable condition at all anymore.