### PR TITLE
add extraPorts for extraContainers

### DIFF
--- a/charts/kminion/templates/service.yaml
+++ b/charts/kminion/templates/service.yaml
@@ -16,5 +16,8 @@ spec:
       targetPort: metrics
       protocol: TCP
       name: metrics
+  {{- if .Values.service.extraPorts }}
+    {{- toYaml .Values.service.extraPorts | nindent 4 }}
+  {{- end }}
   selector:
     {{- include "kminion.selectorLabels" . | nindent 4 }}

--- a/charts/kminion/values.yaml
+++ b/charts/kminion/values.yaml
@@ -50,6 +50,13 @@ service:
   type: ClusterIP
   port: 8080 # This port is also used as exposed container port
   annotations: {} # # Annotations to add to the service
+  extraPorts: [] # when []extraContainers expose additional metrics, make
+                 # discoverable for servicemontors
+    # - port: 8443
+    #   targetPort: 8443
+    #   protocol: TCP
+    #   name: expose-x509-for-ttl-checks
+
 
 ingress:
   enabled: false


### PR DESCRIPTION
In parallel to extraContainers, extraPorts may be required to scrape additional metrics generated by said extraContainers.

Thanks for your work on the kminion prometheus exporter, it has proven to be extremely useful.