### PR TITLE
Add user to docker image to avoid running as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,9 @@ RUN CGO_ENABLED=0 go build \
 FROM alpine:3.17
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/bin/kminion /app/kminion
+RUN addgroup -S redpanda \
+    && adduser -S redpanda -G redpanda \
+    && chmod o+rx /app/kminion
+USER redpanda
 
 ENTRYPOINT ["/app/kminion"]


### PR DESCRIPTION
Add user to docker image to avoid running as root.
The kminion binary is owned by root but is executable by other users.


```
/ $ ls -ll /etc/ssl/certs/ca-certificates.crt
-rw-r--r--    1 root     root        214222 May  8 13:34 /etc/ssl/certs/ca-certificates.crt
/ $ ls -ll /app/
total 13376
-rwxr-xr-x    1 root     root      13697024 May  8 13:34 kminion
```