### PR TITLE
Make kminion helm chart compatible with K8s >= 1.25

### DIFF
--- a/charts/kminion/templates/hpa.yaml
+++ b/charts/kminion/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta1" (.Capabilities.APIVersions.Has "autoscaling/v2") }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "kminion.fullname" . }}
@@ -18,12 +18,24 @@ spec:
     - type: Resource
       resource:
         name: cpu
+        {{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{ else }}
         targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- end }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
+        {{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{ else }}
         targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
`autoscaling/v2beta1` is deprecated in 1.25, reference: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v125

This PR is to ensure that Kminion can be installed in k8s cluster with version >= 1.25 while not dropping support for <=1.23

I've tested the changes in actual K8s clusters with 1.25 and 1.21.