### PR TITLE
helm: allowPrivilegeEscalation=false

### DIFF
--- a/charts/kminion/values.yaml
+++ b/charts/kminion/values.yaml
@@ -38,7 +38,8 @@ podDisruptionBudget:
   maxUnavailable: 1
   # minAvailable: 1
 
-securityContext: {}
+securityContext:
+  allowPrivilegeEscalation: false
 # capabilities:
 #   drop:
 #   - ALL


### PR DESCRIPTION
Containers should not run with allowPrivilegeEscalation in order to prevent them from gaining more privileges than their parent process