### PR TITLE
update docker pull image with latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ All images will be built on each push to master or for every new release. You ca
 in our [DockerHub repository](https://hub.docker.com/r/redpandadata/kminion/tags).
 
 ```shell
-docker pull redpandadata/kminion:v2.2.6
+docker pull redpandadata/kminion:latest
 ```
 
 ### ☸ Helm chart


### PR DESCRIPTION
future-proof the command since latest [tag](https://hub.docker.com/r/redpandadata/kminion/tags) seems to point to tagged releases