### PR TITLE
fix: merge camelCase properties from config file correctly with environment variables

### DIFF
--- a/config.go
+++ b/config.go
@@ -61,7 +61,10 @@ func newConfig(logger *zap.Logger) (Config, error) {
 	if configFilepath == "" {
 		logger.Info("the env variable '" + envKey + "' is not set, therefore no YAML config will be loaded")
 	} else {
-		err := k.Load(file.Provider(configFilepath), yaml.Parser())
+		err := k.Load(file.Provider(configFilepath), yaml.Parser(), koanf.WithMergeFunc(func(src, dest map[string]interface{}) error {
+			dest = src
+			return nil
+		}))
 		if err != nil {
 			return Config{}, fmt.Errorf("failed to parse YAML config: %w", err)
 		}


### PR DESCRIPTION
Small fix to get environment overrides working for camelCase config keys.

closes #179
