### PR TITLE
feat(helm): add tpl to config

### DIFF
--- a/charts/kminion/templates/configmap.yaml
+++ b/charts/kminion/templates/configmap.yaml
@@ -7,4 +7,4 @@ metadata:
     {{- include "kminion.labels" . | nindent 4}}
 data:
   config.yaml: |
-    {{- toYaml .Values.kminion.config | nindent 4}}
+    {{- tpl (toYaml .Values.kminion.config) $ | nindent 4 }}


### PR DESCRIPTION
In case you would have an umbrella chart which would install both kafka and kminion, it would be impossible to inject e.g. the service name for the brokers (which is by default prefixed with the release name).
With this PR for example the following values could be used in an umbrella chart:

```yaml
kminion:
    config:
      kafka:
        brokers:
          - "{{ $.Release.Name }}-kafka.{{ $.Release.Namespace }}:9092"
```
