### PR TITLE
charts/kminion - allow setting priorityClassName for kminion pod

### DIFF
--- a/charts/kminion/templates/deployment.yaml
+++ b/charts/kminion/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
         {{- toYaml . | nindent 8}}
       {{- end}}
       serviceAccountName: {{include "kminion.serviceAccountName" .}}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8}}
       volumes:

--- a/charts/kminion/values.yaml
+++ b/charts/kminion/values.yaml
@@ -23,6 +23,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+priorityClassName:
+
 podAnnotations: {}
 #  prometheus.io/scrape: "true"
 #  prometheus.io/port: "8080"


### PR DESCRIPTION
Hey,

I've been using [cloudworkz/kafka-minion-helm-chart](https://github.com/cloudworkz/kafka-minion-helm-chart) and I was able to set `priorityClassName` on pods, which is not the case in this Chart.

Tell me if you expect anything else in the PR :pray: 

Also I would need a new version to be released as soon as this PR is merged, should I change the version in `Chart.yaml` myself?
