### PR TITLE
fix: ensure each broker is preferred leader for a partition

### DIFF
--- a/e2e/topic.go
+++ b/e2e/topic.go
@@ -130,6 +130,7 @@ func (s *Service) calculatePartitionReassignments(meta *kmsg.MetadataResponse) (
 	// We want to ensure that each brokerID leads at least one partition permanently. Hence let's iterate over brokers.
 	preferredLeaderPartitionsBrokerID := make(map[int32][]kmsg.MetadataResponseTopicPartition)
 	for _, broker := range brokerByID {
+		preferredLeaderPartitionsBrokerID[broker.NodeID] = make([]kmsg.MetadataResponseTopicPartition, 0)
 		for _, partition := range topicMeta.Partitions {
 			// PreferredLeader = BrokerID of the brokerID that is the desired leader. Regardless who the current leader is
 			preferredLeader := partition.Replicas[0]


### PR DESCRIPTION
The end-to-end monitoring service already includes a process to validate that each broker is the preferred leader for at least one partition, but this validation was not run for brokers that were not the preferred leader for any partitions.

For example, this would mean an additional partition would never be created after the initial creation of the management topic in the case of another broker being added to the cluster.

This fix could be a breaking change for users without the required permissions to create partitions or alter partition assignments if they have inadvertently relied on this feature not working as documented.