### PR TITLE
gha: retrieve secrets from aws sm

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -12,11 +12,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           driver-opts: image=moby/buildkit:v0.10.3,network=host
       - name: Set Release Date
@@ -24,7 +24,7 @@ jobs:
           echo "BUILT_AT=$(date --rfc-3339=date)" >> ${GITHUB_ENV}
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -37,13 +37,14 @@ jobs:
             type=sha,prefix={{branch}}-,format=short,enable={{is_default_branch}}
             type=semver,pattern={{raw}}
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
+          provenance: false
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -12,6 +12,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: get secrets from aws sm
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,sdlc/prod/github/dockerhub_token
+          parse-json-secrets: true
       - uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -39,8 +51,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          username: vectorizedbot
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -1,5 +1,5 @@
+---
 name: Build Docker image
-
 on:
   push:
     tags:
@@ -8,26 +8,20 @@ on:
       - "master"
     paths-ignore:
       - 'charts/**'
-
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
           driver-opts: image=moby/buildkit:v0.10.3,network=host
-
       - name: Set Release Date
         run: |
           echo "BUILT_AT=$(date --rfc-3339=date)" >> ${GITHUB_ENV}
-
       - name: Docker meta
         id: docker_meta
         uses: docker/metadata-action@v4
@@ -37,17 +31,16 @@ jobs:
             vectorized/kminion
             redpandadata/kminion
           # generate Docker tags based on the following events/attributes
-          # Semver type is only active on 'push tag' events, hence no enable condition required
+          # Semver type is only active on 'push tag' events,
+          # hence no enable condition required
           tags: |
             type=sha,prefix={{branch}}-,format=short,enable={{is_default_branch}}
             type=semver,pattern={{raw}}
-
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
       - name: Build and push
         uses: docker/build-push-action@v3
         with:


### PR DESCRIPTION
jira: https://redpandadata.atlassian.net/browse/PESDLC-1547

github secrets for this repo have been migrated to aws secretsmanager. this PR uses gha [aws-actions/aws-secretsmanager-get-secrets](https://github.com/aws-actions/aws-secretsmanager-get-secrets) to access the secrets.

also updated the actions to latest versions in `docker-image.yaml`.