### PR TITLE
fix e2e producer

### DIFF
--- a/e2e/service.go
+++ b/e2e/service.go
@@ -155,14 +155,6 @@ func (s *Service) Start(ctx context.Context) error {
 		return fmt.Errorf("could not validate end-to-end topic: %w", err)
 	}
 
-	// Get up-to-date metadata and inform our custom partitioner about the partition count
-	topicMetadata, err := s.getTopicMetadata(ctx)
-	if err != nil {
-		return fmt.Errorf("could not get topic metadata after validation: %w", err)
-	}
-	partitions := len(topicMetadata.Topics[0].Partitions)
-	s.partitionCount = partitions
-
 	// finally start everything else (producing, consuming, continuous validation, consumer group tracking)
 	go s.startReconciliation(ctx)
 

--- a/e2e/topic.go
+++ b/e2e/topic.go
@@ -68,6 +68,10 @@ func (s *Service) validateManagementTopic(ctx context.Context) error {
 		return fmt.Errorf("failed to create partitions: %w", err)
 	}
 
+	// after topic configuration is complete number of partitions must be equal to the number of brokers multiplied
+	// by the partitions per broker
+	s.partitionCount = len(meta.Brokers) * s.config.TopicManagement.PartitionsPerBroker
+
 	return nil
 }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c03054cf-a3e5-4645-a0e5-077c0a82b856)

I've noticed that when working with clusters having several controller and broker nodes, retrieving cluster metadata may occasionally return stale data. This issue is evident when, for example, an end-to-end test topic is created, and the topic metadata is retrieved immediately afterward. In this case, the metadata request may return error code 3, which corresponds to the `UNKNOWN_TOPIC_OR_PARTITION` error. This error likely occurs when a client connects to a broker that is not yet aware of the new topic because it hasn't consumed the latest data from the `__cluster_metadata` topic.

In summary, when the end-to-end code attempts to populate the value of `s.partitionCount`, it might encounter the `UNKNOWN_TOPIC_OR_PARTITION` error, even if the topic actually exists. This results in a partition count of zero, preventing the producer from sending any data.