### PR TITLE
dockerfile: fix casing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ############################################################
 # Build image
 ############################################################
-FROM golang:1.22-alpine as builder
+FROM golang:1.22-alpine AS builder
 
 ARG VERSION
 ARG BUILT_AT


### PR DESCRIPTION
fix for [warning](https://github.com/redpanda-data/kminion/actions/runs/10435392066/job/28899306394#step:10:560) in job after merge to `master`:
>  - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 4)