### PR TITLE
goreleaser - replace deprecated --rm-dist flag with --clean

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -17,7 +17,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
           workdir: .
         env:
           CGO_ENABLED: 0


### PR DESCRIPTION
goreleaser deprecated `--rm-dist` flag in v2: https://goreleaser.com/deprecations/#-rm-dist