### PR TITLE
Change dockerhub secret

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -36,7 +36,6 @@ jobs:
         with:
           # list of Docker images to use as base name for tags
           images: |
-            vectorized/kminion
             redpandadata/kminion
           # generate Docker tags based on the following events/attributes
           # Semver type is only active on 'push tag' events,

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
-            ,sdlc/prod/github/dockerhub_token
+            ,sdlc/prod/github/dockerhub
           parse-json-secrets: true
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -45,7 +45,7 @@ jobs:
             type=semver,pattern={{raw}}
       - uses: docker/login-action@v3
         with:
-          username: vectorizedbot
+          username: ${{ env.DOCKERHUB_USER }}
           password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
Change secret for dockerhub so that the workflow stops using `sdlc/prod/github/dockerhub_token` and instead uses `
sdlc/prod/github/dockerhub`, as this new secret allows to reference other values that comply with the naming guideline
of our company security guidelines.

The publishing of containers to `vectorized` org is also removed in this PR since that is not used by anyone anymore.