### PR TITLE
workflows/goreleaser: use aws sm instead for secret

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
load secret from aws sm instead of gh secrets

jira: [DEVPROD-2730]

[DEVPROD-2730]: https://redpandadata.atlassian.net/browse/DEVPROD-2730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ