### PR TITLE
gha: add permissions to release

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
jira: [DEVPROD-2730]

goreleaser workflow has [error](https://github.com/redpanda-data/kminion/actions/runs/13834955922/job/38707650143#step:4:181):
```
  ⨯ release failed after 1m59s               error=scm releases: failed to publish artifacts: could not release: POST https://api.github.com/repos/redpanda-data/kminion/releases: 403 Resource not accessible by integration []
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.8.0/x64/goreleaser' failed with exit code 1
```

i believe this PR should fix it by granting permissions according to [docs](https://docs.github.com/en/enterprise-cloud@latest/rest/releases/releases?apiVersion=2022-11-28#create-a-release):

> "Contents" repository permissions (write)

similar to PR https://github.com/redpanda-data/docs-ui/pull/267

[DEVPROD-2730]: https://redpandadata.atlassian.net/browse/DEVPROD-2730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ