### PR TITLE
gha: only push to ECR on git tags

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -37,7 +37,7 @@ jobs:
           # list of Docker images to use as base name for tags
           images: |
             redpandadata/kminion
-            public.ecr.aws/l9j0i2e0/kminion
+            name=public.ecr.aws/l9j0i2e0/kminion,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
           # generate Docker tags based on the following events/attributes
           # Semver type is only active on 'push tag' events,
           # hence no enable condition required
@@ -49,10 +49,12 @@ jobs:
           username: ${{ env.DOCKERHUB_USER }}
           password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: aws-actions/configure-aws-credentials@v4
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
       - uses: aws-actions/amazon-ecr-login@v2
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
           registry-type: public
       - uses: docker/build-push-action@v6


### PR DESCRIPTION
Followup to https://github.com/redpanda-data/kminion/pull/289. No need to push for untagged commits.

part of https://redpandadata.atlassian.net/browse/DEVPROD-2735