### PR TITLE
feat: Add ACL related metrics

### DIFF
--- a/minion/acls.go
+++ b/minion/acls.go
@@ -1,0 +1,24 @@
+package minion
+
+import (
+	"context"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+func (s *Service) ListAllACLs(ctx context.Context) (*kmsg.DescribeACLsResponse, error) {
+	req := kmsg.NewDescribeACLsRequest()
+	req.ResourceType = kmsg.ACLResourceTypeAny
+	req.ResourcePatternType = kmsg.ACLResourcePatternTypeAny
+	req.ResourceName = nil
+	req.Principal = nil
+	req.Host = nil
+	req.Operation = kmsg.ACLOperationAny
+	req.PermissionType = kmsg.ACLPermissionTypeAny
+
+	res, err := req.RequestWith(ctx, s.client)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/prometheus/collect_acl_info.go
+++ b/prometheus/collect_acl_info.go
@@ -1,0 +1,69 @@
+package prometheus
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/twmb/franz-go/pkg/kmsg"
+	"go.uber.org/zap"
+)
+
+func (e *Exporter) collectACLInfo(ctx context.Context, ch chan<- prometheus.Metric) bool {
+	ACLRes, err := e.minionSvc.ListAllACLs(ctx)
+	if err != nil {
+		e.logger.Error("failed to fetch ACLs", zap.Error(err))
+		return false
+	}
+
+	ACLsByType := getResourceTypeName(ACLRes)
+	totalACLs := 0
+	for _, count := range ACLsByType {
+		totalACLs += count
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		e.aclCount,
+		prometheus.GaugeValue,
+		float64(totalACLs),
+	)
+
+	for resourceType, count := range ACLsByType {
+		ch <- prometheus.MustNewConstMetric(
+			e.aclCountByType,
+			prometheus.GaugeValue,
+			float64(count),
+			resourceType,
+		)
+	}
+
+	return true
+}
+
+func getResourceTypeName(ACLResponse *kmsg.DescribeACLsResponse) map[string]int {
+	ACLsByType := make(map[string]int)
+	for _, resource := range ACLResponse.Resources {
+		resourceType := "unknown"
+		switch resource.ResourceType {
+		case 0:
+			resourceType = "unknown"
+		case 1:
+			resourceType = "any"
+		case 2:
+			resourceType = "topic"
+		case 3:
+			resourceType = "group"
+		case 4:
+			resourceType = "cluster"
+		case 5:
+			resourceType = "transactional_id"
+		case 6:
+			resourceType = "delegation_token"
+		case 7:
+			resourceType = "user"
+		}
+
+		ACLsByType[resourceType] += len(resource.ACLs)
+	}
+
+	return ACLsByType
+}


### PR DESCRIPTION
Hi team,

This PR aims to add more ACL related metrics for kminion, inititally brought up by https://github.com/redpanda-data/kminion/issues/137. It will now support 2 different types of metrics
- Total number of ACLs
- Total number of ACLs broken down by different type

Below is an example output under `/metrics` endpoint
```
# HELP kminion_kafka_acls_by_type The number of ACLs by resource type
# TYPE kminion_kafka_acls_by_type gauge
kminion_kafka_acls_by_type{resource_type="cluster"} 1
kminion_kafka_acls_by_type{resource_type="group"} 2
kminion_kafka_acls_by_type{resource_type="topic"} 3
kminion_kafka_acls_by_type{resource_type="transactional_id"} 4
# HELP kminion_kafka_acls_total The total number of ACLs in the cluster
# TYPE kminion_kafka_acls_total gauge
kminion_kafka_acls_total 10
```