### PR TITLE
fix: incorrect error usage and typo

### DIFF
--- a/e2e/service.go
+++ b/e2e/service.go
@@ -44,7 +44,7 @@ type Service struct {
 	offsetCommitLatency *prometheus.HistogramVec
 }
 
-// NewService creates a new instance of the e2e moinitoring service (wow)
+// NewService creates a new instance of the e2e monitoring service (wow)
 func NewService(ctx context.Context, cfg Config, logger *zap.Logger, kafkaSvc *kafka.Service, promRegisterer prometheus.Registerer) (*Service, error) {
 	minionID := uuid.NewString()
 	groupID := fmt.Sprintf("%v-%v", cfg.Consumer.GroupIdPrefix, minionID)
@@ -53,7 +53,7 @@ func NewService(ctx context.Context, cfg Config, logger *zap.Logger, kafkaSvc *k
 	kgoOpts := []kgo.Opt{
 		kgo.ProduceRequestTimeout(3 * time.Second),
 		kgo.RecordRetries(3),
-		// We use the manual partitioner so that the records' partition id will be used as target partitio
+		// We use the manual partitioner so that the records' partition id will be used as target partition
 		kgo.RecordPartitioner(kgo.ManualPartitioner()),
 	}
 	if cfg.Producer.RequiredAcks == "all" {

--- a/e2e/topic.go
+++ b/e2e/topic.go
@@ -123,7 +123,7 @@ func (s *Service) executeCreatePartitions(ctx context.Context, req *kmsg.CreateP
 	for _, topic := range res.Topics {
 		typedErr := kerr.TypedErrorForCode(topic.ErrorCode)
 		if typedErr != nil {
-			return fmt.Errorf("inner Kafka error: %w", err)
+			return fmt.Errorf("inner Kafka error: %w", typedErr)
 		}
 	}
 
@@ -397,7 +397,7 @@ func createTopicConfig(cfgTopic EndToEndTopicConfig) []kmsg.CreateTopicsRequestT
 	}
 
 	// Even though kminion's end-to-end feature actually does not require any
-	// real persistence beyond a few minutes; it might be good too keep messages
+	// real persistence beyond a few minutes; it might be good to keep messages
 	// around a bit for debugging.
 	return []kmsg.CreateTopicsRequestTopicConfig{
 		topicConfig("cleanup.policy", "delete"),


### PR DESCRIPTION
https://github.com/redpanda-data/kminion/blob/4b0fb1f1a455156f80d450ab0c5389f0c61520a5/e2e/topic.go#L119-L126

- Now returns the actual Kafka error (`typedErr`) instead of the outer request error, improving error clarity and debugging.
- Fix some typos.