### PR TITLE
gha: update buildkit to v0.21

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: docker/setup-buildx-action@v3
         with:
           driver-opts: |
-            image=moby/buildkit:v0.15.2
+            image=moby/buildkit:v0.21.1
             network=host
       - name: Set build date
         run: |


### PR DESCRIPTION
Attempt to address GHA Cache API v1 deprecation causing docker image build failures.

https://github.com/redpanda-data/kminion/actions/runs/14834250298/job/41642029587
![image](https://github.com/user-attachments/assets/9a49d4a0-72d4-4f60-9c77-a2a5a9b5d3f8)




Refs:
* https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts
* https://docs.docker.com/build/ci/github-actions/cache/#cache-backend-api

![image](https://github.com/user-attachments/assets/b774a81d-6a16-4868-bf2f-1d06bba81c9d)

