### PR TITLE
Check for nil krbClient with GSSAPI

### DIFF
--- a/docs/reference-config.yaml
+++ b/docs/reference-config.yaml
@@ -50,6 +50,7 @@ kafka:
     mechanism: "PLAIN"
     # GSSAPI / Kerberos config properties
     gssapi:
+      # Required. One of USER_AUTH or KEYTAB_AUTH
       authType: ""
       keyTabPath: ""
       kerberosConfigPath: ""

--- a/kafka/client_config_helper.go
+++ b/kafka/client_config_helper.go
@@ -107,6 +107,9 @@ func NewKgoConfig(cfg Config, logger *zap.Logger) ([]kgo.Opt, error) {
 					kerbCfg,
 					client.DisablePAFXFAST(!cfg.SASL.GSSAPI.EnableFast))
 			}
+			if krbClient == nil {
+				return nil, fmt.Errorf("kafka.sasl.gssapi.authType must be one of USER_AUTH or KEYTAB_AUTH")
+			}
 			kerberosMechanism := kerberos.Auth{
 				Client:           krbClient,
 				Service:          cfg.SASL.GSSAPI.ServiceName,


### PR DESCRIPTION
Check for nil krbClient when using GSSAPI. Failure to specify it results in a nil pointer panic:
```
{"level":"debug","ts":"2025-07-22T14:18:23.520Z","logger":"main.kgo_client","msg":"beginning sasl authentication","broker":"seed_0","addr":"t-eu-kafka.test.mwam.local:9092","mechanism":"GSSAPI
","authenticate":false}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x68559a]

goroutine 170 [running]:
github.com/jcmturner/gokrb5/v8/client.(*Client).IsConfigured(0x0?)
        /go/pkg/mod/github.com/jcmturner/gokrb5/v8@v8.4.4/client/client.go:140 +0x1a
...
```