### PR TITLE
fix: e2e test: fix protocol error handling from partition reassignment

### DIFF
--- a/e2e/topic.go
+++ b/e2e/topic.go
@@ -142,13 +142,13 @@ func (s *Service) executeAlterPartitionAssignments(ctx context.Context, req *kms
 
 	typedErr := kerr.TypedErrorForCode(res.ErrorCode)
 	if typedErr != nil {
-		return fmt.Errorf("inner Kafka error: %w", err)
+		return fmt.Errorf("inner Kafka error: %w", typedErr)
 	}
 	for _, topic := range res.Topics {
 		for _, partition := range topic.Partitions {
 			typedErr = kerr.TypedErrorForCode(partition.ErrorCode)
 			if typedErr != nil {
-				return fmt.Errorf("inner Kafka partition error on partition '%v': %w", partition.Partition, err)
+				return fmt.Errorf("inner Kafka partition error on partition '%v': %w", partition.Partition, typedErr)
 			}
 		}
 	}


### PR DESCRIPTION
When the partition assignment fails, the code would return `err` from `eq.RequestWith(ctx, s.client)` call, not the typed protocol error resulting in `could not validate end-to-end topic: failed to alter partition assignments: inner Kafka error: %!w(<nil>)` message.