### PR TITLE
Do not create partitions if it's possible to reassign existing

### DIFF
--- a/e2e/topic.go
+++ b/e2e/topic.go
@@ -221,13 +221,14 @@ func (s *Service) calculatePartitionReassignments(meta *kmsg.MetadataResponse) (
 			partitionReassignments = append(partitionReassignments, req)
 
 			reassignablePartitions = reassignablePartitions[1:]
+		} else {
+			// Create a new partition for this broker
+			partitionCount++
+			assignmentReq := kmsg.NewCreatePartitionsRequestTopicAssignment()
+			assignmentReq.Replicas = s.calculateAppropriateReplicas(meta, desiredReplicationFactor, brokerByID[brokerID])
+			createPartitionAssignments = append(createPartitionAssignments, assignmentReq)
 		}
 
-		// Create a new partition for this broker
-		partitionCount++
-		assignmentReq := kmsg.NewCreatePartitionsRequestTopicAssignment()
-		assignmentReq.Replicas = s.calculateAppropriateReplicas(meta, desiredReplicationFactor, brokerByID[brokerID])
-		createPartitionAssignments = append(createPartitionAssignments, assignmentReq)
 	}
 
 	var reassignmentReq *kmsg.AlterPartitionAssignmentsRequest


### PR DESCRIPTION
Hey all

I have a question/proposal.

If I understood the logic correctly (but please correct me if I'm wrong): the end-to-end test tries its best to ensure that every broker in a cluster has at least 1 partition leader to be able to test the whole cluster. If this condition ceases to be true the `validateManagementTopic` function is meant to do one of:
- If there are enough partitions: redistribute them
- If not enough: create new partitions

If my understanding is correct, there is a bug in logic: if there are reassignable partitions, the code reassigns them AND creates new partitions.