### PR TITLE
Remove MaxVersions option from NewKgoConfig and rely on automatically negotiate the highest supported version with the brokers

### DIFF
--- a/kafka/client_config_helper.go
+++ b/kafka/client_config_helper.go
@@ -30,7 +30,6 @@ import (
 func NewKgoConfig(cfg Config, logger *zap.Logger) ([]kgo.Opt, error) {
 	opts := []kgo.Opt{
 		kgo.SeedBrokers(cfg.Brokers...),
-		kgo.MaxVersions(kversion.V2_7_0()),
 		kgo.ClientID(cfg.ClientID),
 		kgo.FetchMaxBytes(5 * 1000 * 1000), // 5MB
 		kgo.MaxConcurrentFetches(10),


### PR DESCRIPTION
According to the franz-go documentation: "If you use a broker older than 0.10.0, then you need to manually set a MaxVersions option. Otherwise, there is usually no harm in defaulting to empty" Franz-go will automatically negotiate the highest supported version with the brokers.