### PR TITLE
fix: respect topicManagement.enabled for validation and alteration

### DIFF
--- a/docs/reference-config.yaml
+++ b/docs/reference-config.yaml
@@ -119,8 +119,23 @@ minion:
     # How often to send end-to-end test messages
     probeInterval: 100ms
     topicManagement:
-      # You can disable topic management, without disabling the testing feature.
-      # Only makes sense if you have multiple kminion instances, and for some reason only want one of them to create/configure the topic
+      # Controls whether kminion should create, validate, and alter the end-to-end topic.
+      #
+      # When enabled (true):
+      # - kminion creates the topic if it doesn't exist
+      # - Validates partition count and replica assignments on startup and periodically (based on reconciliationInterval)
+      # - Alters the topic (reassigns partitions, adds partitions) to ensure one partition leader per broker
+      # - Fails on startup if topic alteration operations fail
+      #
+      # When disabled (false):
+      # - kminion will NOT create the topic if it doesn't exist (startup will fail)
+      # - Will NOT validate or alter an existing topic (accepts current partition layout as-is)
+      # - Logs warnings if the topic configuration is suboptimal
+      # - Continues end-to-end testing with whatever partition layout exists
+      #
+      # Use disabled mode on managed Kafka platforms that restrict partition reassignment operations.
+      # In this mode, you must manually create the topic with appropriate partition distribution
+      # before starting kminion.
       enabled: true
 
       # Name of the topic kminion uses to send its test messages

--- a/kafka/client_config_helper.go
+++ b/kafka/client_config_helper.go
@@ -13,7 +13,6 @@ import (
 	"github.com/jcmturner/gokrb5/v8/client"
 	"github.com/jcmturner/gokrb5/v8/keytab"
 	"github.com/twmb/franz-go/pkg/kgo"
-	"github.com/twmb/franz-go/pkg/kversion"
 	"github.com/twmb/franz-go/pkg/sasl"
 	"github.com/twmb/franz-go/pkg/sasl/kerberos"
 	"github.com/twmb/franz-go/pkg/sasl/oauth"


### PR DESCRIPTION
Fixes #313

When `topicManagement.enabled: false`, kminion now skips topic validation and alteration on startup. This prevents crashes on managed Kafka platforms that block partition reassignment operations.

The fix adds a check to skip the validation logic when topic management is disabled, while still logging warnings if the topic configuration is suboptimal.