### PR TITLE
Implement liveness check

### DIFF
--- a/charts/kminion/templates/daemonset.yaml
+++ b/charts/kminion/templates/daemonset.yaml
@@ -91,7 +91,7 @@ spec:
           livenessProbe:
             failureThreshold: 3
             httpGet:
-              path: /ready
+              path: /live
               port: metrics
               scheme: HTTP
             initialDelaySeconds: 10

--- a/charts/kminion/templates/deployment.yaml
+++ b/charts/kminion/templates/deployment.yaml
@@ -94,6 +94,16 @@ spec:
             {{- end}}
           resources:
             {{- toYaml .Values.resources | nindent 12}}
+          {{- if .Values.deployment.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /live
+              port: {{.Values.service.port}}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 1
+          {{- end }}
           {{- if .Values.deployment.readinessProbe.enabled }}
           readinessProbe:
             httpGet:

--- a/charts/kminion/values.yaml
+++ b/charts/kminion/values.yaml
@@ -144,6 +144,8 @@ daemonset:
   enabled: false
 
 deployment:
+  livenessProbe:
+    enabled: true
   readinessProbe:
     enabled: true
 

--- a/main.go
+++ b/main.go
@@ -109,6 +109,7 @@ func main() {
 		),
 	)
 	http.Handle("/ready", minionSvc.HandleIsReady())
+	http.Handle("/live", minionSvc.HandleIsLive())
 
 	// Start HTTP server
 	address := net.JoinHostPort(cfg.Exporter.Host, strconv.Itoa(cfg.Exporter.Port))

--- a/minion/service.go
+++ b/minion/service.go
@@ -130,6 +130,18 @@ func (s *Service) HandleIsReady() http.HandlerFunc {
 	}
 }
 
+func (s *Service) HandleIsLive() http.HandlerFunc {
+	type response struct {
+		StatusCode int `json:"statusCode"`
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		res := response{StatusCode: http.StatusOK}
+		resJson, _ := json.Marshal(res)
+		w.WriteHeader(http.StatusOK)
+		w.Write(resJson)
+	}
+}
+
 // ensureCompatibility checks whether the options as configured are available in the connected cluster. For example
 // we will check if the target Kafka's API version support the LogDirs request. If that's not the case we will
 // disable the option and print a warning message.


### PR DESCRIPTION
Previously there was no liveness probe on the Deployment, and the DaemonSet reused /ready for both probes. In OffsetsTopic scrape mode, /ready returns 503 until the consumer catches up on __consumer_offsets, which can take minutes on large clusters. Using /ready for liveness would cause Kubernetes to kill pods that are still starting up. The new /live endpoint avoids this by only checking that the HTTP server is responsive.

Work
- [x] Add /live HTTP endpoint that always returns 200, separating liveness from readiness concerns
- [x] Add liveness probe configuration to the Helm Deployment template (enabled by default)
- [x] Update DaemonSet template to use /live instead of reusing /ready for liveness

