### PR TITLE
Bump Go to 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ############################################################
 # Build image
 ############################################################
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 ARG VERSION
 ARG BUILT_AT

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudhut/kminion/v2
 
-go 1.25
+go 1.26
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
## Summary
- Bumps Go from 1.25 to 1.26 in Dockerfile and go.mod
- Picks up Go 1.26 stdlib security fixes (CVE-2026-27139, CVE-2026-25679, CVE-2026-27142)
- Builder image uses `golang:1.26-alpine`

## Test plan
- [ ] CI passes
- [ ] Docker image builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)