### PR TITLE
fix: deduplicate consumer groups to prevent scrape failure (#335)

### DIFF
--- a/prometheus/collect_consumer_groups.go
+++ b/prometheus/collect_consumer_groups.go
@@ -23,6 +23,24 @@ func (e *Exporter) collectConsumerGroups(ctx context.Context, ch chan<- promethe
 
 	// The list of groups may be incomplete due to group coordinators that might fail to respond. We do log an error
 	// message in that case (in the kafka request method) and groups will not be included in this list.
+	//
+	// seenGroups deduplicates consumer groups to prevent duplicate metric emission.
+	//
+	// Root cause: listConsumerGroups calls ListGroups via franz-go, which fans the
+	// request out to ALL brokers simultaneously (listGroupsSharder → allBrokersShardedReq).
+	// Each broker responds with the groups it currently believes it coordinates, and
+	// franz-go merges the responses by simple concatenation. During a coordinator
+	// migration (common when large consumer groups rebalance), both the old and new
+	// coordinator broker may transiently include the same group in their ListGroups
+	// response, producing duplicate group IDs in the merged list.
+	//
+	// Those duplicate IDs flow into DescribeGroups, causing the same group to appear
+	// multiple times in the DescribeGroups response. Without this guard, group-level
+	// metrics (consumer_group_info, consumer_group_members, …) would be emitted more
+	// than once per scrape cycle, and the Prometheus registry would reject the entire
+	// scrape with "collected metric … was collected before with the same name and
+	// label values".
+	seenGroups := make(map[string]struct{})
 	for _, grp := range groups {
 		coordinator := grp.BrokerMetadata.NodeID
 		for _, group := range grp.Groups.Groups {
@@ -37,6 +55,14 @@ func (e *Exporter) collectConsumerGroups(ctx context.Context, ch chan<- promethe
 			if !e.minionSvc.IsGroupAllowed(group.Group) {
 				continue
 			}
+			if _, seen := seenGroups[group.Group]; seen {
+				e.logger.Debug("skipping duplicate consumer group from broker shard response",
+					zap.String("group_id", group.Group),
+					zap.Int32("broker_id", coordinator),
+				)
+				continue
+			}
+			seenGroups[group.Group] = struct{}{}
 			state := 0
 			if group.State == "Stable" {
 				state = 1


### PR DESCRIPTION
## Problem

When a Kafka cluster has consumer groups with 38+ active members subscribed to 5+ topics, kminion fails to serve **any** metrics with:

```
An error has occurred while serving metrics:
collected metric "kminion_kafka_consumer_group_info" { label:{name:"group_id" value:"my-group"} ... }
was collected before with the same name and label values
```

The Prometheus registry rejects the entire scrape — zero metrics exported. Reproducible on both `adminApi` and `offsetsTopic` scrape modes.

Fixes #335

## Root Cause

`listConsumerGroups` calls `ListGroups` via franz-go, which uses `listGroupsSharder` → `allBrokersShardedReq` to fan the request out to **all brokers simultaneously**. franz-go merges responses by simple concatenation (`merged.Groups = append(merged.Groups, resp.Groups...)`). 

During a coordinator migration (common when large consumer groups rebalance), both the old and new coordinator broker transiently include the same group in their `ListGroups` response, producing duplicate group IDs in the merged list.

Those duplicate IDs flow into `DescribeGroups`, causing the same group to appear multiple times in the response. Without a guard, `consumer_group_info` and `consumer_group_members` are emitted more than once per scrape, and Prometheus rejects the entire scrape.

## Fix

Add a per-cycle `seenGroups` map in `collectConsumerGroups` so each group emits its metrics exactly once, regardless of how many broker shard responses contain it.

## Impact

- **No change in normal operation** — the `seenGroups` map is a no-op when no duplicates exist
- **During coordinator migration** (rare, transient): first shard response wins (ordered by broker node ID); data self-corrects on the next scrape cycle
- **Lag metrics unaffected** — `collectConsumerGroupLags` is a separate path and not touched by this change

## Testing

Manually tested on Debian 11 against a 3-broker Kafka cluster with 38+ member consumer groups. `/metrics` endpoint returns cleanly without duplicate errors.

---

> Note: fix approach informed by AI analysis; logic reviewed and tested manually.