### PR TITLE
security: upgrade Alpine packages in builder stage to patch OpenSSL CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG VERSION
 ARG BUILT_AT
 ARG COMMIT
 
-RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates
+RUN apk update && apk upgrade --no-cache && apk add --no-cache git ca-certificates && update-ca-certificates
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- Adds `apk upgrade --no-cache` to the Dockerfile builder stage so both build and runtime stages pick up the latest Alpine OS packages on each image rebuild
- The runtime stage already had this step; the builder stage was missing it
- A fresh build will pull patched OpenSSL, resolving 5 Snyk findings in `redpandadata/kminion:latest`

## CVEs Resolved

| Severity | CVE | Score |
|----------|-----|-------|
| Critical | CVE-2026-31789 | 198 |
| High | CVE-2026-28387 | 174 |
| High | CVE-2026-28389 | 121 |
| High | CVE-2026-28388 | 121 |
| High | CVE-2026-28390 | 121 |

All are OpenSSL vulnerabilities in Alpine 3.23. No Known Exploit for any finding.

## Test plan

- [ ] Merge and tag `v2.3.1` per the [release runbook](docs/on-call/runbooks/upgrades/release_a_new_version_of_kminion.md)
- [ ] Verify Snyk container scan on the new image shows no OpenSSL findings
- [ ] Update `redpanda_kminion_container_image.tag` to `v2.3.1` in cloudv2 ([CIAINFRA-2909](https://redpandadata.atlassian.net/browse/CIAINFRA-2909))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CIAINFRA-2909]: https://redpandadata.atlassian.net/browse/CIAINFRA-2909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ