### PR TITLE
Bump Go toolchain to 1.26.3 to address Snyk findings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ############################################################
 # Build image
 ############################################################
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 
 ARG VERSION
 ARG BUILT_AT

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudhut/kminion/v2
 
-go 1.26
+go 1.26.3
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
## Summary
Pin Go toolchain to 1.26.3 in `go.mod` and the build image to fix HIGH-severity stdlib CVEs flagged by Snyk.

- CVE-2026-33811 Double Free in std/net (GO-2026-4981)
- CVE-2026-39836 Uncaught Exception in std/net (GO-2026-4971)
- CVE-2026-33814 Infinite loop in std/net/http (GO-2026-4918)

All three are fixed in Go 1.26.3.

## Changes
- `go.mod`: `go 1.26` -> `go 1.26.3`
- `Dockerfile`: `golang:1.26-alpine` -> `golang:1.26.3-alpine`

## Test plan
- [ ] CI build passes on Go 1.26.3
- [ ] Snyk re-scan shows the three findings cleared