### PR TITLE
feat: add TLS/HTTPS support for the exporter HTTP server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,9 @@ COPY --from=builder /app/bin/kminion /app/kminion
 RUN addgroup -S redpanda \
     && adduser -S redpanda -G redpanda \
     && chmod o+rx /app/kminion \
-    && apk upgrade --no-cache
+    && apk upgrade --no-cache \
+    && mkdir -p /etc/kminion/tls \
+    && chown -R redpanda:redpanda /etc/kminion
 USER redpanda
 
 ENTRYPOINT ["/app/kminion"]

--- a/charts/kminion/templates/daemonset.yaml
+++ b/charts/kminion/templates/daemonset.yaml
@@ -40,6 +40,11 @@ spec:
           secret:
             secretName: {{.secretName}}
         {{- end}}
+        {{- if .Values.deployment.tlsEnabled }}
+        - name: exporter-tls
+          secret:
+            secretName: {{ .Values.deployment.tlsCertSecret }}
+        {{- end }}
       containers:
         - name: {{.Chart.Name}}
           securityContext:
@@ -86,24 +91,43 @@ spec:
             - name: {{.secretName}}
               mountPath: {{.mountPath}}
             {{- end}}
+            {{- if .Values.deployment.tlsEnabled }}
+            - name: exporter-tls
+              mountPath: {{ .Values.deployment.tlsMountPath }}
+              readOnly: true
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12}}
           livenessProbe:
             failureThreshold: 3
+            {{- if .Values.deployment.tlsEnabled }}
+            httpsGet:
+              path: /ready
+              port: metrics
+              scheme: HTTPS
+            {{- else }}
             httpGet:
               path: /ready
               port: metrics
               scheme: HTTP
+            {{- end }}
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
           readinessProbe:
             failureThreshold: 3
+            {{- if .Values.deployment.tlsEnabled }}
+            httpsGet:
+              path: /ready
+              port: metrics
+              scheme: HTTPS
+            {{- else }}
             httpGet:
               path: /ready
               port: metrics
               scheme: HTTP
+            {{- end }}
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1

--- a/charts/kminion/templates/daemonset.yaml
+++ b/charts/kminion/templates/daemonset.yaml
@@ -100,34 +100,28 @@ spec:
             {{- toYaml .Values.resources | nindent 12}}
           livenessProbe:
             failureThreshold: 3
-            {{- if .Values.deployment.tlsEnabled }}
-            httpsGet:
-              path: /ready
-              port: metrics
-              scheme: HTTPS
-            {{- else }}
             httpGet:
               path: /ready
               port: metrics
+              {{- if .Values.deployment.tlsEnabled }}
+              scheme: HTTPS
+              {{- else }}
               scheme: HTTP
-            {{- end }}
+              {{- end }}
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
           readinessProbe:
             failureThreshold: 3
-            {{- if .Values.deployment.tlsEnabled }}
-            httpsGet:
-              path: /ready
-              port: metrics
-              scheme: HTTPS
-            {{- else }}
             httpGet:
               path: /ready
               port: metrics
+              {{- if .Values.deployment.tlsEnabled }}
+              scheme: HTTPS
+              {{- else }}
               scheme: HTTP
-            {{- end }}
+              {{- end }}
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1

--- a/charts/kminion/templates/deployment.yaml
+++ b/charts/kminion/templates/deployment.yaml
@@ -50,6 +50,11 @@ spec:
         {{- with .Values.deployment.volumes.extra }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- if .Values.deployment.tlsEnabled }}
+        - name: exporter-tls
+          secret:
+            secretName: {{ .Values.deployment.tlsCertSecret }}
+        {{- end }}
       initContainers:
       {{- with .Values.deployment.initContainers }}
       {{- toYaml . | nindent 8 }}
@@ -92,13 +97,24 @@ spec:
             - name: {{.secretName}}
               mountPath: {{.mountPath}}
             {{- end}}
+            {{- if .Values.deployment.tlsEnabled }}
+            - name: exporter-tls
+              mountPath: {{ .Values.deployment.tlsMountPath }}
+              readOnly: true
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12}}
           {{- if .Values.deployment.readinessProbe.enabled }}
           readinessProbe:
+            {{- if .Values.deployment.tlsEnabled }}
+            httpsGet:
+              path: /ready
+              port: {{ .Values.service.port }}
+            {{- else }}
             httpGet:
               path: /ready
-              port: {{.Values.service.port}}
+              port: {{ .Values.service.port }}
+            {{- end }}
             initialDelaySeconds: 10
           {{- end }}
         {{- with .Values.deployment.extraContainers }}

--- a/charts/kminion/templates/deployment.yaml
+++ b/charts/kminion/templates/deployment.yaml
@@ -104,17 +104,23 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12}}
-          {{- if .Values.deployment.readinessProbe.enabled }}
-          readinessProbe:
-            {{- if .Values.deployment.tlsEnabled }}
-            httpsGet:
-              path: /ready
-              port: {{ .Values.service.port }}
-            {{- else }}
+          livenessProbe:
             httpGet:
               path: /ready
-              port: {{ .Values.service.port }}
-            {{- end }}
+              port: {{.Values.service.port}}
+              {{- if .Values.deployment.tlsEnabled }}
+              scheme: HTTPS
+              {{- end }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          {{- if .Values.deployment.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: {{.Values.service.port}}
+              {{- if .Values.deployment.tlsEnabled }}
+              scheme: HTTPS
+              {{- end }}
             initialDelaySeconds: 10
           {{- end }}
         {{- with .Values.deployment.extraContainers }}

--- a/charts/kminion/templates/servicemonitor.yaml
+++ b/charts/kminion/templates/servicemonitor.yaml
@@ -19,6 +19,11 @@ spec:
       honorLabels: {{ .Values.serviceMonitor.honorLabels }}
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
       interval: {{ .Values.serviceMonitor.interval }}
+      {{- if .Values.deployment.tlsEnabled }}
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+      {{- end }}
       {{- if .Values.serviceMonitor.relabelings }}
       relabelings:
       {{ toYaml .Values.serviceMonitor.relabelings | nindent 6 }}

--- a/charts/kminion/values.yaml
+++ b/charts/kminion/values.yaml
@@ -159,6 +159,13 @@ deployment:
     # - name: example
     #   emptyDir: {}
 
+  # TLS configuration for the exporter HTTP server
+  tlsEnabled: false
+  # Name of a Kubernetes secret containing tls.crt and tls.key
+  tlsCertSecret: ""
+  # Path inside the container where the TLS secret will be mounted
+  tlsMountPath: /etc/kminion/tls
+
   # If you want to provide specifc config settings like sensitive Kafka credentials via environment variables you can
   # do so by making them available here. See the kminion reference config to figure out the expected variable names.
   env:
@@ -189,6 +196,10 @@ kminion:
   # end up in a YAML file which will be mounted into the kminion container.
   # See reference config: https://github.com/cloudhut/kminion/blob/master/docs/reference-config.yaml
   config: {}
+#    exporter:
+#      tlsEnabled: false
+#      tlsCertFilepath: ""
+#      tlsKeyFilepath: ""
 #    kafka:
 #      brokers: [ ]
 #      clientId: "kminion"

--- a/config.go
+++ b/config.go
@@ -42,6 +42,13 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("failed to validate minion config: %w", err)
 	}
 
+	if c.Exporter.TLSEnabled && c.Exporter.TLSCertFilepath == "" {
+		return fmt.Errorf("exporter TLS is enabled but 'tlsCertFilepath' is not set")
+	}
+	if c.Exporter.TLSEnabled && c.Exporter.TLSKeyFilepath == "" {
+		return fmt.Errorf("exporter TLS is enabled but 'tlsKeyFilepath' is not set")
+	}
+
 	err = c.Logger.Validate()
 	if err != nil {
 		return fmt.Errorf("failed to validate logger config: %w", err)

--- a/docs/reference-config.yaml
+++ b/docs/reference-config.yaml
@@ -194,3 +194,9 @@ exporter:
   host: ""
   # Port that shall be used to bind the HTTP server on
   port: 8080
+  # Whether or not TLS shall be enabled for the HTTP server
+  tlsEnabled: false
+  # Filepath to the TLS certificate (PEM format)
+  tlsCertFilepath: ""
+  # Filepath to the TLS private key (PEM format)
+  tlsKeyFilepath: ""

--- a/main.go
+++ b/main.go
@@ -120,10 +120,17 @@ func main() {
 			os.Exit(1)
 		}
 	}()
-	logger.Info("listening on address", zap.String("listen_address", address))
-	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-		logger.Error("error starting HTTP server", zap.Error(err))
-		os.Exit(1)
+	logger.Info("listening on address", zap.String("listen_address", address), zap.Bool("tls_enabled", cfg.Exporter.TLSEnabled))
+	if cfg.Exporter.TLSEnabled {
+		if err := srv.ListenAndServeTLS(cfg.Exporter.TLSCertFilepath, cfg.Exporter.TLSKeyFilepath); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("error starting HTTPS server", zap.Error(err))
+			os.Exit(1)
+		}
+	} else {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("error starting HTTP server", zap.Error(err))
+			os.Exit(1)
+		}
 	}
 
 	logger.Info("kminion stopped")

--- a/prometheus/config.go
+++ b/prometheus/config.go
@@ -1,9 +1,12 @@
 package prometheus
 
 type Config struct {
-	Host      string `koanf:"host"`
-	Port      int    `koanf:"port"`
-	Namespace string `koanf:"namespace"`
+	Host            string `koanf:"host"`
+	Port            int    `koanf:"port"`
+	Namespace       string `koanf:"namespace"`
+	TLSEnabled      bool   `koanf:"tlsEnabled"`
+	TLSCertFilepath string `koanf:"tlsCertFilepath"`
+	TLSKeyFilepath  string `koanf:"tlsKeyFilepath"`
 }
 
 func (c *Config) SetDefaults() {


### PR DESCRIPTION
## Summary
Adds native TLS/HTTPS support for the exporter HTTP server, so `/metrics` and `/ready` endpoints can be served over HTTPS without a reverse proxy.
## Configuration
YAML:
```yaml
exporter:
  tlsEnabled: true
  tlsCertFilepath: /etc/kminion/tls/server.crt
  tlsKeyFilepath: /etc/kminion/tls/server.key
```
Environment variables: EXPORTER_TLSENABLED, EXPORTER_TLSCERTFILEPATH, EXPORTER_TLSKEYFILEPATH
Helm values: deployment.tlsEnabled, deployment.tlsCertSecret, deployment.tlsMountPath
What's included
- Config fields + validation (tlsEnabled, tlsCertFilepath, tlsKeyFilepath)
- Conditional ListenAndServeTLS in main.go
- Dockerfile: /etc/kminion/tls directory for mounting certs
- Helm chart: TLS volume/mount, httpsGet probes (deployment + daemonset), scheme: https in ServiceMonitor
Similar to #258, but with explicit tlsEnabled flag, config validation, and full Helm chart support.