### PR TITLE
deps: bump Go to 1.26.4 to address Snyk findings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ############################################################
 # Build image
 ############################################################
-FROM golang:1.26.3-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 ARG VERSION
 ARG BUILT_AT

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudhut/kminion/v2
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
## What
Bumps the `go` directive (`go.mod`) and the builder base image (`Dockerfile`: `golang:1.26.3-alpine` → `golang:1.26.4-alpine`) to **1.26.4**.

## Why
Clears two stdlib HIGH Snyk findings:
- **CVE-2026-27145** / GO-2026-5037 — `crypto/x509` resource exhaustion
- **CVE-2026-42504** / GO-2026-5038 — `net/mime` resource exhaustion

Both fixed in go1.26.4. (`golang:1.26.4-alpine` confirmed available on Docker Hub.)

## References
- https://pkg.go.dev/vuln/GO-2026-5037
- https://pkg.go.dev/vuln/GO-2026-5038

🤖 Generated with [Claude Code](https://claude.com/claude-code)