### PR TITLE
security: bump Go toolchain to 1.26.5 (CVE-2026-39822)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ############################################################
 # Build image
 ############################################################
-FROM golang:1.26.3-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 ARG VERSION
 ARG BUILT_AT

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudhut/kminion/v2
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
## Summary

Fixes Snyk finding **SNYK-GOLANG-STDOS-17905377** (High) — CVE-2026-39822, a symlink attack (CWE-59) in the Go standard library `os` package. On Unix, `os.Root` could improperly follow symlinks pointing outside the designated root directory, particularly when paths end with a trailing `/`.

This is a stdlib/toolchain vulnerability (no third-party dependency involved), remediated by bumping the Go toolchain to the 1.26.5 patch release.

## Changes

- `go.mod`: `go 1.26.3` → `go 1.26.5`
- `Dockerfile`: builder image `golang:1.26.3-alpine` → `golang:1.26.5-alpine`

Fixed versions per the advisory: 1.25.12 / 1.26.5 / 1.27.0-rc.2 or higher.

## Verification

- `go build ./...` passes on go1.26.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)