### PR TITLE
security: bump Go toolchain to 1.26.6 (stdlib CVEs)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ############################################################
 # Build image
 ############################################################
-FROM golang:1.26.5-alpine AS builder
+FROM golang:1.26.6-alpine AS builder
 
 ARG VERSION
 ARG BUILT_AT

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudhut/kminion/v2
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
## Summary

Bumps the Go toolchain from 1.26.5 to 1.26.6 (`go.mod` go directive + Dockerfile builder image), fixing the four high-severity Go standard library vulnerabilities Snyk flagged on 2026-08-17. All are remediated in the [go1.26.6 patch release](https://go.dev/doc/devel/release) (2026-08-13):

| CVE | Snyk issue | Package | Issue |
|---|---|---|---|
| CVE-2026-56853 | SNYK-GOLANG-STDNETHTTP-18858429 | net/http | DoS: ReadHeaderTimeout not applied while sniffing HTTP/2 preface |
| CVE-2026-56862 | SNYK-GOLANG-STDCRYPTOTLS-18858453 | crypto/tls | DoS |
| CVE-2026-46600 | SNYK-GOLANG-STDNET-18858450 | net | Uncaught exception |
| CVE-2026-56860 | SNYK-GOLANG-STDNETURL-18858438 | net/url | DoS |

Same shape as #344 (previous stdlib CVE toolchain bump).

## Verification

- `go build ./...` and `go test ./...` pass locally on go1.26.6
- `golang:1.26.6-alpine` tag confirmed present on Docker Hub
- `snyk test --file=go.mod --severity-threshold=high`: 213 dependencies tested, no vulnerable paths found

🤖 Generated with [Claude Code](https://claude.com/claude-code)